### PR TITLE
Exclude libraries where ABI lab couldn't find debuginfo files

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -2,6 +2,7 @@ import fnmatch
 import json
 import os
 from glob import glob
+import re
 
 import pandas
 
@@ -127,6 +128,12 @@ def create_fedora_results_table(experiments, filename=False):
             analysis = p["command"]
         elif predictor == "libabigail":
             analysis = "abidiff"
+        
+        # ABI lab generate pass/fail results even when it can't find a debug file
+        # The debug files are present. This appears to be a bug in ABI lab.
+        if analysis == "abi-compliance-tester":
+          if re.search("ERROR: can't find debug info in object", p["message"], re.DOTALL):
+            prediction = "NODEBUG"
 
         row = [
             before,

--- a/make_results_table.sql
+++ b/make_results_table.sql
@@ -12,6 +12,6 @@ delete from results where original in(select distinct original from results wher
 CREATE TABLE two_predictors("a" text, "b" text, "original" text, "changed" text, "analysis" text, "time" float, "predictor" text, "prediction" text);
 insert into two_predictors select * from results where predictor<>'abi-laboratory';
 
--- 'three_predictors' contains all results from predictors except those libraries where abi-lab crashed
+-- 'three_predictors' contains all results from predictors except those libraries where abi-lab crashed or couldn't find a debuginfo file
 CREATE TABLE three_predictors("a" text, "b" text, "original" text, "changed" text, "analysis" text, "time" float, "predictor" text, "prediction" text);
-insert into three_predictors select * from results where original not in(select distinct original from results where prediction='Terminated');
+insert into three_predictors select * from results where original not in(select distinct original from results where prediction in('Terminated','NODEBUG'));

--- a/messages.summary
+++ b/messages.summary
@@ -1,6 +1,6 @@
 three_predictors.changed.messages
-Total libs: 118
-abigail total: 107
+Total libs: 107
+abigail total: 104
 abigail SONAME soname_changed:
     total: 85
     Functions:
@@ -28,10 +28,10 @@ abigail SONAME soname_changed:
         removed: 41,7
           added: 38,4
 abigail SONAME soname_unchanged:
-    total: 22
+    total: 19
     Functions:
-          total: 20
-        removed: 8,4
+          total: 19
+        removed: 7,3
         changed: 15,4
           added: 12,1
     Function subtype changes:
@@ -41,9 +41,9 @@ abigail SONAME soname_unchanged:
           added: 1
         removed: 1
     Function symbols:
-          total: 5
+          total: 2
         removed: 2,0
-          added: 5,3
+          added: 2,0
     Variables:
           total: 2
         removed: 2,0
@@ -54,15 +54,15 @@ abigail SONAME soname_unchanged:
         removed: 4,3
           added: 1,0
 --------------------
-abilab total: 88
-    no debug: 11
+abilab total: 77
+    no debug: 0
 --------------------
-symbols total: 92
+symbols total: 91
       no _chk: 22
 
 three_predictors.unchanged.messages
-Total libs: 1562
-abigail total: 952
+Total libs: 1165
+abigail total: 928
 abigail SONAME soname_changed:
     total: 52
     Functions:
@@ -90,11 +90,11 @@ abigail SONAME soname_changed:
         removed: 0,0
           added: 0,0
 abigail SONAME soname_unchanged:
-    total: 900
+    total: 876
     Functions:
-          total: 812
+          total: 788
         removed: 600,475
-        changed: 230,155
+        changed: 206,131
           added: 179,9
     Function subtype changes:
           total: 34
@@ -116,11 +116,11 @@ abigail SONAME soname_unchanged:
         removed: 37,36
           added: 8,7
 --------------------
-abilab total: 1238
-    no debug: 361
+abilab total: 877
+    no debug: 0
 --------------------
-symbols total: 606
-      no _chk: 64
+symbols total: 569
+      no _chk: 52
 
 two_predictors.changed.messages
 Total libs: 880


### PR DESCRIPTION
ABI lab would return a prediction even in the case that it couldn't find a debuginfo file. I have manually verified that those files are present. This appears to be a bug in ABI lab.