### PR TITLE
Switch to missing-previously-found-exports

### DIFF
--- a/agreement.py
+++ b/agreement.py
@@ -50,7 +50,7 @@ def agreement(table, filename_changed, max_match):
 
 print("Fraction of libraries where all predictors agree:")
 print("-" * 70)
-for t, m in (("two_predictors", 3), ("three_predictors", 4)):
+for t, m in (("two_predictors", 2), ("three_predictors", 3)):
     print(f" {t}\n", "-" * 20)
     for fnc in (True, False):
         frac = []

--- a/counts_matrix.py
+++ b/counts_matrix.py
@@ -75,8 +75,8 @@ def run(table, predictors):
         print("\n")
 
 
-predictors = ("missing-previously-found-symbols", "abidiff")
+predictors = ("missing-previously-found-exports", "abidiff")
 run("two_predictors", predictors)
 
-predictors = ("missing-previously-found-symbols", "abidiff", "abi-compliance-tester")
+predictors = ("missing-previously-found-exports", "abidiff", "abi-compliance-tester")
 run("three_predictors", predictors)

--- a/make_results_table.sql
+++ b/make_results_table.sql
@@ -8,6 +8,9 @@
 -- 'Unknown' results are linker script files
 delete from results where original in(select distinct original from results where prediction="Unknown");
 
+-- Keep only the missing-previously-found-exports from the symbols predictor
+delete from results where predictor = 'symbols' and analysis = 'missing-previously-found-symbols';
+
 -- 'two_predictors' contains all results except those from abi-laboratory
 CREATE TABLE two_predictors("a" text, "b" text, "original" text, "changed" text, "analysis" text, "time" float, "predictor" text, "prediction" text);
 insert into two_predictors select * from results where predictor<>'abi-laboratory';

--- a/messages.summary
+++ b/messages.summary
@@ -1,5 +1,5 @@
 three_predictors.changed.messages
-Total libs: 107
+Total libs: 105
 abigail total: 104
 abigail SONAME soname_changed:
     total: 85
@@ -67,11 +67,10 @@ abigail SONAME soname_unchanged:
 abilab total: 77
     no debug: 0
 --------------------
-symbols total: 91
-      no _chk: 22
+symbols total: 89
 
 three_predictors.unchanged.messages
-Total libs: 1165
+Total libs: 991
 abigail total: 928
 abigail SONAME soname_changed:
     total: 52
@@ -139,11 +138,10 @@ abigail SONAME soname_unchanged:
 abilab total: 877
     no debug: 0
 --------------------
-symbols total: 569
-      no _chk: 52
+symbols total: 395
 
 two_predictors.changed.messages
-Total libs: 880
+Total libs: 839
 abigail total: 839
 abigail SONAME soname_changed:
     total: 230
@@ -211,11 +209,10 @@ abigail SONAME soname_unchanged:
 abilab total: 0
     no debug: 0
 --------------------
-symbols total: 725
-      no _chk: 169
+symbols total: 684
 
 two_predictors.unchanged.messages
-Total libs: 1844
+Total libs: 1376
 abigail total: 1376
 abigail SONAME soname_changed:
     total: 52
@@ -283,6 +280,5 @@ abigail SONAME soname_unchanged:
 abilab total: 0
     no debug: 0
 --------------------
-symbols total: 1133
-      no _chk: 255
+symbols total: 665
 

--- a/parse_messages.pl
+++ b/parse_messages.pl
@@ -68,9 +68,6 @@ while(<$fdOut>) {
 		}
 	} elsif(/^missing-previously-found-symbols/) {
 		$counts{'symbols'}{'count'}++;
-		if(/\b.+_chk\b/) {
-			$counts{'symbols'}{'missing_chk'}++;
-		}
 	}
 }
 
@@ -138,4 +135,3 @@ print "abilab total: ", $counts{'abilab'}{'count'}||0;
 print "    no debug: ", $counts{'abilab'}{'nodebug'}||0;
 print '-'x20;
 print "symbols total: $counts{'symbols'}{'count'}";
-print "      no _chk: $counts{'symbols'}{'missing_chk'}";


### PR DESCRIPTION
This simplifies the results comparison against the symbols predictor since we're only working with exported symbols. The calculation of imported symbols revealed mostly missing symbols from glibc. It didn't add much to the discussion compared to it's mental cost for both me and the reader. Notably, it removes the need for the _chk symbol discussion. missing-exports is also effectively what the other symbol comparison tools would be looking at. This does not change the number of libraries analyzed- only the relative agreement between predictors.